### PR TITLE
Add polyfills for IE11 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,7 +1612,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -1625,7 +1625,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -2910,10 +2910,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-      "dev": true
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3961,6 +3960,11 @@
         "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -7206,7 +7210,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -15966,7 +15970,7 @@
           "dev": true,
           "requires": {
             "ast-types": "0.10.1",
-            "core-js": "2.5.3",
+            "core-js": "2.5.7",
             "esprima": "4.0.0",
             "private": "0.1.8",
             "source-map": "0.6.1"
@@ -16323,9 +16327,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
     "build": "node build/build.js"
   },
   "dependencies": {
+    "core-js": "^2.5.7",
+    "es6-promise": "^4.2.4",
     "i18next": "^11.3.2",
     "i18next-browser-languagedetector": "^2.2.0",
     "i18next-xhr-backend": "^1.5.1",
     "js-cookie": "^2.2.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "react-i18next": "^7.6.1"
+    "react-i18next": "^7.6.1",
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import './polyfills'
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './main.css';

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,3 @@
+import 'whatwg-fetch'
+import 'es6-promise/auto'
+import 'core-js/fn/string/includes'


### PR DESCRIPTION
Polyfill features that are not natively supported in IE11:

- fetch
- promise
- String.prototype.includes

These polyfills are needed by Oma Opintopolku and/or oppija raamit. This adds the polyfills to Oma Opintopolku, which also serves them for raamit.