### PR TITLE
Ulkoasun korjauksia mobiilikäyttäjille

### DIFF
--- a/src/components/greeting/Greeting.css
+++ b/src/components/greeting/Greeting.css
@@ -2,9 +2,14 @@
   :local(.greeting-container) {
     margin-left: 15px;
   }
+
+  :local(.guest-header) {
+    text-align: center;
+  }
 }
 
-:local(.heading) {}
+:local(.heading) {
+}
 
 :local(.greeting-container) {
   display: flex;
@@ -22,10 +27,11 @@
 }
 
 :local(.guest-greeting) {
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   font-weight: 500;
   width: 70%;
-  margin: 1.67em auto 0.67em auto;
+  text-align: center;
+  margin: 0 auto;
 }
 
 :local(.subtitle) {
@@ -54,4 +60,3 @@
   font-size: 16px;
   margin-top: 0px;
 }
-

--- a/src/components/greeting/Greeting.css
+++ b/src/components/greeting/Greeting.css
@@ -29,7 +29,7 @@
 :local(.guest-greeting) {
   font-size: 1.2rem;
   font-weight: 500;
-  width: 70%;
+  width: 80%;
   text-align: center;
   margin: 0 auto;
 }

--- a/src/components/selection/Selection.css
+++ b/src/components/selection/Selection.css
@@ -24,7 +24,7 @@
 @media screen and (max-width: 900px) {
   :local(.bottom-container) {
     flex-direction: column;
-    width: 30rem;
+    width: 100%;
     margin: 1rem auto;
   }
 }


### PR DESCRIPTION
Simppelit muutokset etusivun tyyleihin, kun käyttäjä ei ole kirjautunut. Huomattavasti parempi puhelimella. 

Muutokset:
- Korjattu horisontaalinen overflow puhelimilla
- Pienennetty tekstiä hieman jotta ei vie niin huomattavaa osaa näytöstä kerralla
- Keskitetty otsikko puhelimilla

Kuvat ennen ja jälkeen (huom. paikallisessa devissä ei näy opintopolku headeriä)


### Mobiili

<img src="https://github.com/user-attachments/assets/b299581d-41d2-42f5-93a3-bee5a750f282" alt="fi_oma-opintopolku_(iPhone 14 Pro Max)" width="400"/>

<img src="https://github.com/user-attachments/assets/ffbc8130-251f-461e-b751-2f8ebc9f2fe7" alt="fi_oma-opintopolku_(iPhone 14 Pro Max)" width="400"/>


### Työpöytä

![opintopolku fi_oma-opintopolku_](https://github.com/user-attachments/assets/239f0bfe-c3d9-4e8d-8941-2e05d0068b77)

![localhost_8080_oma-opintopolku_](https://github.com/user-attachments/assets/19ad8bde-80ed-4de2-bf33-8316f25501f5)
